### PR TITLE
feat: Update RKE2 provisioner versions

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -17,7 +17,7 @@ rke2_longhorn_storage: false
 rke2_longhorn_storage_path: /var/lib/longhorn
 rke2_server_kubeconfig: /etc/rancher/rke2/rke2.yaml
 rke2_selinux: true
-rke2_selinux_version: '0.18'
+rke2_selinux_version: '0.18.stable.1'
 
 # here is where you can override default ingress-nginx helm config
 # (the default defaults are in vars/main.yaml)

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -12,7 +12,7 @@ rke2_manifests_dir: /var/lib/rancher/rke2/server/manifests
 rke2_local_storage: false
 rke2_local_storage_path: /var/lib/rancher/rke2/storage
 rke2_local_storage_storageclass_name: local
-rke2_local_path_provisioner_version: v0.0.24
+rke2_local_path_provisioner_version: v0.0.30
 rke2_longhorn_storage: false
 rke2_longhorn_storage_path: /var/lib/longhorn
 rke2_server_kubeconfig: /etc/rancher/rke2/rke2.yaml


### PR DESCRIPTION
## Changes

- Update local-path-provisioner from v0.0.24 to v0.0.30
- Update RKE2 SELinux from v0.18 to v0.18.stable.1

## Improvements

### Local Path Provisioner (v0.0.30)
- Enhanced SELinux context handling
- Improved error handling
- Better storage volume management

### RKE2 SELinux (v0.18.stable.1)
- Latest stable release in the 0.18.x series
- Includes security fixes and improvements

## Testing Checklist
- [ ] Test in staging environment
- [ ] Verify persistent volume creation and access
- [ ] Check SELinux logs for unexpected behaviors
- [ ] Validate cluster stability

## Risk Assessment
- Verified no breaking changes in version updates
- Changes are backward compatible
- Easy rollback possible if needed